### PR TITLE
Add Authors field and object-level permissions

### DIFF
--- a/helpothers/settings.py
+++ b/helpothers/settings.py
@@ -138,6 +138,7 @@ INSTALLED_APPS = (
 
     'leaflet',
     'geoposition',
+    'guardian',
     'social.apps.django_app.default',
     'gunicorn',
 
@@ -162,8 +163,10 @@ AUTHENTICATION_BACKENDS = (
     'social.backends.google.GoogleOAuth2',
     'social.backends.twitter.TwitterOAuth',
     'django.contrib.auth.backends.ModelBackend',
+    'guardian.backends.ObjectPermissionBackend',
 )
 
+ANONYMOUS_USER_ID = -1
 
 SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
 

--- a/helpothers/views.py
+++ b/helpothers/views.py
@@ -4,6 +4,8 @@ from django.views.generic.base import TemplateView
 from django.views.generic.detail import DetailView
 from django.views.generic.edit import CreateView
 
+from guardian.shortcuts import assign_perm
+
 from listings.models import GatheringCenter, Resource
 
 
@@ -45,8 +47,16 @@ class ResourceCreateView(CreateView):
     template_name = 'listings/resources/create.html'
     fields = ['name', 'description', 'url']
 
+    def form_valid(self, form):
+        form.instance.author = self.request.user
+        response = super(ResourceCreateView, self).form_valid(form)
+        assign_perm('listings.change_resource', self.object.author, self.object)
+        assign_perm('listings.delete_resource', self.object.author, self.object)
+        return response
+
     def get_success_url(self):
         return reverse('resource-review')
+
 
 class ReviewView(TemplateView):
     """

--- a/listings/migrations/0006_auto_20151030_2004.py
+++ b/listings/migrations/0006_auto_20151030_2004.py
@@ -16,7 +16,7 @@ def render(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('listings', '0004_auto_20151030_2003'),
+        ('listings', '0005_auto_20151030_2003'),
     ]
 
     operations = [

--- a/listings/migrations/0008_auto_20151031_1353.py
+++ b/listings/migrations/0008_auto_20151031_1353.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('listings', '0007_auto_20151030_2013'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='gatheringcenter',
+            name='author',
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True),
+        ),
+        migrations.AddField(
+            model_name='resource',
+            name='author',
+            field=models.ForeignKey(to=settings.AUTH_USER_MODEL, null=True),
+        ),
+    ]

--- a/listings/models.py
+++ b/listings/models.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import User
 from django.db import models
 from django.utils.translation import ugettext as _
 
@@ -51,6 +52,7 @@ class GatheringCenter(TimeStampedModel):
         default='',
         default_markup_type='markdown',
     )
+    author = models.ForeignKey(User, null=True)
     # TODO add infomartion about what is needed the most
 
     def __unicode__(self):
@@ -67,6 +69,7 @@ class Resource(TimeStampedModel):
     sticky = models.BooleanField(blank=True, default=False)
     published = models.BooleanField(blank=True, default=False)
     country = CountryField(null=True)
+    author = models.ForeignKey(User, null=True)
 
     def __unicode__(self):
         return self.name

--- a/listings/tests/test_views.py
+++ b/listings/tests/test_views.py
@@ -1,0 +1,38 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from django_fakery import factory
+
+from listings import models
+
+
+class ListingViewsTestCase(TestCase):
+    def setUp(self):
+        self.regularuser = factory.make(
+            'auth.User',
+            fields={
+                'username': 'regularuser',
+                'password': 'regularuser',
+                'is_staff': False,
+            }
+        )
+
+    def test_resource_add(self):
+        url = reverse('resource-add')
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 200)
+
+        self.client.login(username='regularuser', password='regularuser')
+
+        payload = {
+            'name': 'resource name',
+            'description': 'lorem ipsum',
+            'url': 'http://example.com'
+        }
+
+        response = self.client.post(url, payload)
+        self.assertEqual(response.status_code, 302)
+
+        resource = models.Resource.objects.get(name='resource name')
+        self.assertEqual(resource.author, self.regularuser)
+        self.assertTrue(self.regularuser.has_perm('listings.change_resource', resource))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 Django==1.8.5
 django-countries==3.4.1
+django-fakery==1.1.1
 django-leaflet==0.16.0
 django-geoposition==0.2.2
+django-guardian==1.3.1
 django-markupfield==1.3.5
 django-model-utils==2.3.1
 gunicorn==19.3.0


### PR DESCRIPTION
For now I've only add permissions to the `ResourceCreateView`, since #9 is already adding the view for creating `GatheringCenter`s.

I've also include tests, but I think we should add the `.travis.yml` on a separate PR